### PR TITLE
Resolve a cold dependency graph in parallel, over one checksum

### DIFF
--- a/sources/build/jenesis/maven/MavenDefaultRepository.java
+++ b/sources/build/jenesis/maven/MavenDefaultRepository.java
@@ -255,59 +255,30 @@ public class MavenDefaultRepository implements MavenRepository {
             if (Files.exists(cached)) {
                 boolean valid = true;
                 if (validate) {
-                    Map<LazyRepositoryItem, byte[]> results = new HashMap<>();
                     for (Map.Entry<String, URI> entry : validations.entrySet()) {
                         LazyRepositoryItem item = fetch(
                                 entry.getValue(),
                                 path + "." + entry.getKey().toLowerCase(Locale.ROOT),
                                 false);
+                        Optional<InputStream> candidate = item.toLazyInputStream();
+                        if (candidate.isEmpty()) {
+                            continue;
+                        }
+                        byte[] published;
+                        try (InputStream inputStream = candidate.get()) {
+                            published = inputStream.readAllBytes();
+                        }
+                        valid = Arrays.equals(toChecksum(published), digest(entry.getKey(), cached));
                         if (valid) {
-                            MessageDigest digest;
+                            item.storeIfNotPresent(published);
+                        } else if (writable) {
                             try {
-                                digest = MessageDigest.getInstance(entry.getKey());
-                            } catch (NoSuchAlgorithmException e) {
-                                throw new IllegalStateException(e);
-                            }
-                            try (FileChannel channel = FileChannel.open(cached)) {
-                                ByteBuffer buffer = ByteBuffer.allocate(1 << 16);
-                                while (channel.read(buffer) != -1) {
-                                    buffer.flip();
-                                    digest.update(buffer);
-                                    buffer.clear();
-                                }
-                            }
-                            Optional<InputStream> candidate = item.toLazyInputStream();
-                            if (candidate.isPresent()) {
-                                byte[] expected;
-                                try (InputStream inputStream = candidate.get()) {
-                                    expected = inputStream.readAllBytes();
-                                }
-                                results.put(item, expected);
-                                String text = new String(expected, StandardCharsets.UTF_8).strip();
-                                int end = 0;
-                                while (end < text.length() && !Character.isWhitespace(text.charAt(end))) {
-                                    end++;
-                                }
-                                valid = Arrays.equals(
-                                        HexFormat.of().parseHex(text.substring(0, end)),
-                                        digest.digest());
-                            }
-                        } else {
-                            results.put(item, null);
-                        }
-                    }
-                    if (valid) {
-                        for (Map.Entry<LazyRepositoryItem, byte[]> entry : results.entrySet()) {
-                            entry.getKey().storeIfNotPresent(entry.getValue());
-                        }
-                    } else if (writable) {
-                        try {
-                            Files.delete(cached);
-                            for (LazyRepositoryItem item : results.keySet()) {
+                                Files.delete(cached);
                                 item.deleteIfPresent();
+                            } catch (IOException _) {
                             }
-                        } catch (IOException _) {
                         }
+                        break;
                     }
                 }
                 if (valid) {
@@ -321,19 +292,13 @@ public class MavenDefaultRepository implements MavenRepository {
                 }
             }
         }
-        Map<LazyRepositoryItem, MessageDigest> digests = new HashMap<>();
+        SequencedMap<LazyRepositoryItem, MessageDigest> digests = new LinkedHashMap<>();
         if (validate) {
             for (Map.Entry<String, URI> entry : validations.entrySet()) {
-                LazyRepositoryItem item = fetch(entry.getValue(),
-                        path + "." + entry.getKey().toLowerCase(Locale.ROOT),
-                        false);
-                MessageDigest digest;
-                try {
-                    digest = MessageDigest.getInstance(entry.getKey());
-                } catch (NoSuchAlgorithmException e) {
-                    throw new IllegalStateException(e);
-                }
-                digests.put(item, digest);
+                digests.put(fetch(entry.getValue(),
+                                path + "." + entry.getKey().toLowerCase(Locale.ROOT),
+                                false),
+                        digest(entry.getKey()));
             }
         }
         URI uri = repository.resolve(path);
@@ -348,7 +313,7 @@ public class MavenDefaultRepository implements MavenRepository {
     }
 
     private static Optional<Path> download(URI uri,
-                                           Map<LazyRepositoryItem, MessageDigest> digests,
+                                           SequencedMap<LazyRepositoryItem, MessageDigest> digests,
                                            String prefix,
                                            String suffix,
                                            String token,
@@ -395,43 +360,63 @@ public class MavenDefaultRepository implements MavenRepository {
                     buffer.clear();
                 }
             }
-            String invalid = null;
-            Map<LazyRepositoryItem, byte[]> results = new HashMap<>();
             for (Map.Entry<LazyRepositoryItem, MessageDigest> entry : digests.entrySet()) {
                 Optional<InputStream> candidate = entry.getKey().toLazyInputStream();
-                if (candidate.isPresent()) {
-                    byte[] expected;
-                    try (InputStream inputStream = candidate.get()) {
-                        expected = inputStream.readAllBytes();
-                    }
-                    results.put(entry.getKey(), expected);
-                    String text = new String(expected, StandardCharsets.UTF_8).strip();
-                    int end = 0;
-                    while (end < text.length() && !Character.isWhitespace(text.charAt(end))) {
-                        end++;
-                    }
-                    if (!Arrays.equals(
-                            HexFormat.of().parseHex(text.substring(0, end)),
-                            entry.getValue().digest())) {
-                        invalid = entry.getValue().getAlgorithm();
-                        break;
-                    }
+                if (candidate.isEmpty()) {
+                    continue;
                 }
-            }
-            if (invalid != null) {
-                for (LazyRepositoryItem item : digests.keySet()) {
-                    item.deleteIfPresent();
+                byte[] published;
+                try (InputStream inputStream = candidate.get()) {
+                    published = inputStream.readAllBytes();
                 }
-                throw new IllegalStateException("Failed checksum validation for " + invalid);
-            }
-            for (Map.Entry<LazyRepositoryItem, byte[]> entry : results.entrySet()) {
-                entry.getKey().storeIfNotPresent(entry.getValue());
+                if (!Arrays.equals(toChecksum(published), entry.getValue().digest())) {
+                    for (LazyRepositoryItem item : digests.keySet()) {
+                        item.deleteIfPresent();
+                    }
+                    throw new IllegalStateException("Failed checksum validation for "
+                            + uri
+                            + " against its "
+                            + entry.getValue().getAlgorithm()
+                            + " checksum");
+                }
+                entry.getKey().storeIfNotPresent(published);
+                break;
             }
         } catch (Throwable t) {
             Files.deleteIfExists(temporary);
             throw t;
         }
         return Optional.of(temporary);
+    }
+
+    private static MessageDigest digest(String algorithm) {
+        try {
+            return MessageDigest.getInstance(algorithm);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("Unknown checksum algorithm: " + algorithm, e);
+        }
+    }
+
+    private static byte[] digest(String algorithm, Path file) throws IOException {
+        MessageDigest digest = digest(algorithm);
+        try (FileChannel channel = FileChannel.open(file)) {
+            ByteBuffer buffer = ByteBuffer.allocate(1 << 16);
+            while (channel.read(buffer) != -1) {
+                buffer.flip();
+                digest.update(buffer);
+                buffer.clear();
+            }
+        }
+        return digest.digest();
+    }
+
+    private static byte[] toChecksum(byte[] published) {
+        String text = new String(published, StandardCharsets.UTF_8).strip();
+        int end = 0;
+        while (end < text.length() && !Character.isWhitespace(text.charAt(end))) {
+            end++;
+        }
+        return HexFormat.of().parseHex(text.substring(0, end));
     }
 
     private static Path move(Path source, Path target) throws IOException {
@@ -492,7 +477,7 @@ public class MavenDefaultRepository implements MavenRepository {
 
     record LatentRepositoryItem(Path path,
                                 URI uri,
-                                Map<LazyRepositoryItem, MessageDigest> digests,
+                                SequencedMap<LazyRepositoryItem, MessageDigest> digests,
                                 String prefix,
                                 String suffix,
                                 String token,

--- a/sources/build/jenesis/maven/MavenPomResolver.java
+++ b/sources/build/jenesis/maven/MavenPomResolver.java
@@ -100,8 +100,8 @@ public class MavenPomResolver implements MavenResolver {
         Traversal traversal = dependencies(executor,
                 MavenRepository.of(repositories.getOrDefault(Resolver.base(prefix), Repository.empty())),
                 new ContextualPom(new ResolvedPom(managedDependencies, dependencies, List.of()), true, null, Set.of(), null, null),
-                new HashMap<>(),
-                new HashMap<>(),
+                new ConcurrentHashMap<>(),
+                new ConcurrentHashMap<>(),
                 prefix);
         SequencedMap<String, String> resolved = new LinkedHashMap<>();
         traversal.dependencies().forEach((key, value) -> resolved.put(
@@ -151,8 +151,8 @@ public class MavenPomResolver implements MavenResolver {
                         Set.of(),
                         null,
                         null),
-                new HashMap<>(),
-                new HashMap<>(),
+                new ConcurrentHashMap<>(),
+                new ConcurrentHashMap<>(),
                 null).dependencies();
     }
 
@@ -208,8 +208,8 @@ public class MavenPomResolver implements MavenResolver {
             Map<MavenDependencyKey, MavenDependencyValue> managedCoordinates,
             MavenDependencyScope scope,
             String prefix) throws IOException {
-        Map<DependencyCoordinate, UnresolvedPom> unresolved = new HashMap<>();
-        Map<DependencyCoordinate, ResolvedPom> resolved = new HashMap<>();
+        Map<DependencyCoordinate, UnresolvedPom> unresolved = new ConcurrentHashMap<>();
+        Map<DependencyCoordinate, ResolvedPom> resolved = new ConcurrentHashMap<>();
         Map<MavenDependencyKey, MavenDependencyValue> managedDependencies = new LinkedHashMap<>(managedCoordinates);
         SequencedMap<MavenDependencyKey, MavenDependencyValue> dependencies = new LinkedHashMap<>();
         SequencedMap<String, MavenDependencyKey> roots = new LinkedHashMap<>();
@@ -276,8 +276,8 @@ public class MavenPomResolver implements MavenResolver {
                                                                                String version,
                                                                                MavenDependencyScope scope)
             throws IOException {
-        Map<DependencyCoordinate, UnresolvedPom> unresolved = new HashMap<>();
-        Map<DependencyCoordinate, ResolvedPom> resolved = new HashMap<>();
+        Map<DependencyCoordinate, UnresolvedPom> unresolved = new ConcurrentHashMap<>();
+        Map<DependencyCoordinate, ResolvedPom> resolved = new ConcurrentHashMap<>();
         return dependencies(executor,
                 repository,
                 new ContextualPom(resolveOrCached(executor,
@@ -377,7 +377,7 @@ public class MavenPomResolver implements MavenResolver {
                                                       String prefix,
                                                       List<Resolver.Edge> edges) throws IOException {
         SequencedSet<MavenDependencyKey> conflicting = new LinkedHashSet<>();
-        Queue<ContextualPom> queue = new ArrayDeque<>();
+        Queue<PendingPom> queue = new ArrayDeque<>();
         do {
             for (Map.Entry<MavenDependencyKey, MavenDependencyValue> entry : current.pom().dependencies().entrySet()) {
                 if (current.exclusions().contains(MavenDependencyName.EXCLUDE_ALL)) {
@@ -456,19 +456,48 @@ public class MavenPomResolver implements MavenResolver {
                         exclusions.addAll(value.exclusions());
                     }
                     if (!exclusions.contains(MavenDependencyName.EXCLUDE_ALL)) {
-                        ResolvedPom pom = resolveOrCached(executor,
+                        queue.add(new PendingPom(dispatch(executor,
                                 repository,
                                 entry.getKey().groupId(),
                                 entry.getKey().artifactId(),
                                 version,
                                 resolved,
-                                unresolved);
-                        queue.add(new ContextualPom(pom, false, scope, exclusions, entry.getKey(), value.version()));
+                                unresolved), scope, exclusions, entry.getKey(), value.version()));
                     }
                 }
             }
-        } while ((current = queue.poll()) != null);
+            PendingPom pending = queue.poll();
+            current = pending == null ? null : pending.awaited();
+        } while (current != null);
         return conflicting;
+    }
+
+    private CompletableFuture<ResolvedPom> dispatch(Executor executor,
+                                                    MavenRepository repository,
+                                                    String groupId,
+                                                    String artifactId,
+                                                    String version,
+                                                    Map<DependencyCoordinate, ResolvedPom> resolved,
+                                                    Map<DependencyCoordinate, UnresolvedPom> unresolved) {
+        ResolvedPom cached = resolved.get(new DependencyCoordinate(groupId, artifactId, version));
+        if (cached != null) {
+            return CompletableFuture.completedFuture(cached);
+        }
+        CompletableFuture<ResolvedPom> pending = new CompletableFuture<>();
+        executor.execute(() -> {
+            try {
+                pending.complete(resolveOrCached(executor,
+                        repository,
+                        groupId,
+                        artifactId,
+                        version,
+                        resolved,
+                        unresolved));
+            } catch (Throwable t) {
+                pending.completeExceptionally(t);
+            }
+        });
+        return pending;
     }
 
     private static void bindChecksum(MavenDependencyKey key,
@@ -595,7 +624,11 @@ public class MavenPomResolver implements MavenResolver {
             throws IOException, SAXException, ParserConfigurationException {
         Document document;
         try (inputStream) {
-            document = factory.newDocumentBuilder().parse(inputStream);
+            DocumentBuilder builder;
+            synchronized (factory) {
+                builder = factory.newDocumentBuilder();
+            }
+            document = builder.parse(inputStream);
         }
         String namespace = document.getDocumentElement().getNamespaceURI();
         return switch (namespace == null ? NAMESPACE_4_0_0 : namespace) {
@@ -1284,6 +1317,25 @@ public class MavenPomResolver implements MavenResolver {
                                  Set<MavenDependencyName> exclusions,
                                  MavenDependencyKey origin,
                                  String originVersion) {
+    }
+
+    private record PendingPom(CompletableFuture<ResolvedPom> pom,
+                              MavenDependencyScope scope,
+                              Set<MavenDependencyName> exclusions,
+                              MavenDependencyKey origin,
+                              String originVersion) {
+
+        private ContextualPom awaited() throws IOException {
+            try {
+                return new ContextualPom(pom.join(), false, scope, exclusions, origin, originVersion);
+            } catch (CompletionException e) {
+                switch (e.getCause()) {
+                    case IOException cause -> throw cause;
+                    case RuntimeException cause -> throw cause;
+                    case null, default -> throw e;
+                }
+            }
+        }
     }
 
     private record Traversal(SequencedMap<MavenDependencyKey, MavenDependencyValue> dependencies,

--- a/tests/build/jenesis/test/maven/MavenDefaultRepositoryTest.java
+++ b/tests/build/jenesis/test/maven/MavenDefaultRepositoryTest.java
@@ -456,6 +456,72 @@ public class MavenDefaultRepositoryTest {
     }
 
     @Test
+    public void stops_probing_sidecars_once_the_strongest_validated() throws IOException, NoSuchAlgorithmException {
+        Files.writeString(Files
+                .createDirectories(repository.resolve("group/artifact/1"))
+                .resolve("artifact-1.jar"), "foo");
+        byte[] hash = MessageDigest.getInstance("SHA512").digest("foo".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(repository.resolve("group/artifact/1/artifact-1.jar.sha512"),
+                HexFormat.of().formatHex(hash));
+        Files.writeString(repository.resolve("group/artifact/1/artifact-1.jar.sha1"),
+                HexFormat.of().formatHex(new byte[20]));
+        Map<String, URI> validations = new LinkedHashMap<>();
+        validations.put("SHA512", repository.toUri());
+        validations.put("SHA1", repository.toUri());
+        Path dependency = result.resolve("dependency.jar");
+        try (InputStream inputStream = new MavenDefaultRepository(repository.toUri(),
+                local,
+                validations, _ -> {}).fetch(Runnable::run,
+                "group",
+                "artifact",
+                "1",
+                "jar",
+                null,
+                null).orElseThrow().toInputStream()) {
+            Files.copy(inputStream, dependency);
+        }
+        assertThat(dependency).content().isEqualTo("foo");
+        assertThat(local.resolve("group/artifact/1/artifact-1.jar.sha512"))
+                .content().isEqualTo(HexFormat.of().formatHex(hash));
+        assertThat(local.resolve("group/artifact/1/artifact-1.jar.sha1"))
+                .as("a weaker sidecar must not be read once a stronger one validated")
+                .doesNotExist();
+    }
+
+    @Test
+    public void stops_probing_sidecars_of_a_cached_artifact_once_the_strongest_validated()
+            throws IOException, NoSuchAlgorithmException {
+        Files.writeString(Files
+                .createDirectories(local.resolve("group/artifact/1"))
+                .resolve("artifact-1.jar"), "foo");
+        byte[] hash = MessageDigest.getInstance("SHA512").digest("foo".getBytes(StandardCharsets.UTF_8));
+        Files.writeString(Files
+                .createDirectories(repository.resolve("group/artifact/1"))
+                .resolve("artifact-1.jar.sha512"), HexFormat.of().formatHex(hash));
+        Files.writeString(repository.resolve("group/artifact/1/artifact-1.jar.sha1"),
+                HexFormat.of().formatHex(new byte[20]));
+        Map<String, URI> validations = new LinkedHashMap<>();
+        validations.put("SHA512", repository.toUri());
+        validations.put("SHA1", repository.toUri());
+        Path dependency = result.resolve("dependency.jar");
+        try (InputStream inputStream = new MavenDefaultRepository(repository.toUri(),
+                local,
+                validations, _ -> {}).fetch(Runnable::run,
+                "group",
+                "artifact",
+                "1",
+                "jar",
+                null,
+                null).orElseThrow().toInputStream()) {
+            Files.copy(inputStream, dependency);
+        }
+        assertThat(dependency).content().isEqualTo("foo");
+        assertThat(local.resolve("group/artifact/1/artifact-1.jar.sha1"))
+                .as("a weaker sidecar must not be read once a stronger one validated")
+                .doesNotExist();
+    }
+
+    @Test
     public void can_fetch_metadata() throws IOException {
         Files.writeString(Files
                 .createDirectories(repository.resolve("group/artifact"))


### PR DESCRIPTION
Two round trips dominated a cold resolution, and neither had to.

## One checksum instead of three

`MavenDefaultRepository` validated an artifact against every configured algorithm in turn, so `SHA512`, `SHA256` and `SHA1` were each requested whether or not a stronger one had already matched. The JUnit console launcher's 19 artifacts cost 76 requests: 19 downloads and 57 sidecars.

The validations are now walked in their configured order and the first sidecar the repository actually publishes decides. That is one request where a repository publishes SHA512, and unchanged where it publishes only SHA1, which is still the common case for older artifacts on Central. `SHA256` deliberately stays in the default chain even though it is redundant with `SHA512` there, because Artifactory publishes `sha1`/`sha256` and no `sha512`, and dropping it would silently downgrade those mirrors to SHA-1.

A miss on the artifact itself still costs exactly one request: the sidecars are read after the download, not before it, so a repository chain still falls through cheaply.

## A POM frontier in flight at once

`MavenPomResolver.traverse` fetched one document at a time. Maven's tree resolution serializes what it must -- a POM's dependencies are unknown until it arrives, and nearest-definition-wins depends on BFS order -- but the fetches do not have to wait on each other.

Every followed edge now dispatches its fetch onto the executor and joins the future when that node is polled, so a whole level is in flight at once and the next level starts while the current one drains. The decisions stay sequential and in the order they had, which is what keeps the resolution identical. Supporting changes: the `resolved`/`unresolved` caches are `ConcurrentHashMap`, and `factory.newDocumentBuilder()` is guarded by a lock on the factory. It is not thread-safe: it calls `fSecurityManager.readSystemProperties()`, which writes the factory's shared `XMLSecurityManager` `values[]`/`states[]` arrays on every call. The lock covers builder creation only, never the parse, which reads from the network. Version negotiation (`RELEASE`, `LATEST`, ranges) stays on the calling thread, because it decides *what* to fetch. Parallelism is unbounded, matching `Resolver.materializeAll`; the BFS bounds the in-flight window to about one level.

## Measured

Cold cache, against Maven Central:

| target | before | after | requests |
|---|---|---|---|
| junit-platform-console (9 jars) | 3.24 s | **1.54 s** | 76 -> 38 |
| maven-core 3.9.9 (31 jars) | 16.00 s | **4.53 s** | 184 -> 176 |
| spring-boot-starter-web 3.4.1 (34 jars) | 17.99 s | **8.86 s** | 214 -> 186 |

For junit-platform-console the metadata phase alone went from 10 strictly serial fetches over 1.74 s to 0.86 s. What remains is dependency depth, which no resolver can collapse.

## Verified

- The resolutions are unchanged. For each graph above, the installed `jpx.properties` -- which lists every jar and carries a digest over all of them -- is byte-identical to the one produced by `main`'s resolver, compiled separately and run against the same repositories.
- `mvn test`: 1840 pass, including two new tests covering the probe stopping at the strongest published sidecar, on the download path and on the cached path.
- Clean self-build (`java build/jenesis/Make.java`) green.