### PR TITLE
jpx --pin prints the run it would make, so the run repeats

### DIFF
--- a/demo/demo-50-jpx/README.md
+++ b/demo/demo-50-jpx/README.md
@@ -8,7 +8,9 @@ JUnit Platform Console Launcher, asked for its `--version`, named twice: once by
 its Java **module name** and once by its **Maven coordinate**. Both name a
 version, and both are verified against the installation's SHA-256 before the JVM
 starts. Two further runs exercise that hash: one supplies only the first 32 hex
-characters of it, and one supplies a digest that does not match and is refused.
+characters of it, and one supplies a digest that does not match and is refused. A
+fourth run **pins** instead of launching: it installs and verifies as the others
+do, then prints the two commands the run stands for rather than starting it.
 
 This is the only demo with nothing of its own to compile. There is no `pom.xml`,
 no `module-info.java` and no `sources/` folder: everything it runs was released by
@@ -37,6 +39,10 @@ what it launched:
     OS: Linux 7.0.0-28-generic amd64
 
     [... and the module name once more, with a 32-character prefix ...]
+
+    jpx --pin --hash=ed5600ef861c7e86cab68c134c6ca0cf3b5265e5f2697c16576281452aa1e2dd org.junit.platform.console@6.1.3 --version
+      [pinned]   jpx --hash=SHA-256/ed5600ef861c7e86cab68c134c6ca0cf3b5265e5f2697c16576281452aa1e2dd org.junit.platform.console@6.1.3 --version
+      [expands]  /path/to/bin/java -p target/jpx/modular_to_maven/org.junit.platform.console@6.1.3/org.apiguardian.api-1.1.2.jar:...:target/jpx/modular_to_maven/org.junit.platform.console@6.1.3/org.opentest4j.reporting.tooling.spi-0.2.5.jar -m org.junit.platform.console/org.junit.platform.console.ConsoleLauncher --version
 
     jpx --hash=ed5600ef861c7e86cab68c134c6ca0cf3b5265e5f2697c16576281452ac0ffee org.junit.platform.console@6.1.3 --version
       [blocked]  Checksum mismatch for org.junit.platform.console@6.1.3: expected a digest starting with 9b60...c0ffee but computed 9b60...cfd3e8
@@ -114,7 +120,7 @@ only `ed5600ef861c7e86cab68c134c6ca0cf` - the first 32 hex characters, which is
 also the shortest accepted. Anything shorter is refused outright rather than
 checked loosely: 32 hex characters is 128 bits, the floor at which a prefix still
 pins the bytes. A leading `SHA-256/` is stripped, so the `checksum` line can be
-pasted in verbatim. The fourth run supplies a full-length digest ending in
+pasted in verbatim. The last run supplies a full-length digest ending in
 `c0ffee` instead of `cfd3e8` - the shape a transcription slip takes - and is
 blocked before the JVM starts:
 
@@ -124,6 +130,49 @@ blocked before the JVM starts:
 Nothing about that failure depends on the version being wrong or the download
 having gone astray: the same message is what a tampered jar produces, because the
 check is over bytes rather than over names.
+
+Pinning the run instead of making it
+------------------------------------
+
+`--pin` is the demo's fourth run. Everything a real run does still happens - the
+target is resolved, the closure is installed, and `--hash` is checked - and only
+the last step is replaced: two commands are printed and the JVM is never started.
+
+    java build/jenesis/Jpx.java --pin org.junit.platform.console --version
+
+The first line is the **jpx command that repeats this run**, written so it
+reproduces. Whatever was typed, the printed form always names the version that
+was resolved and always carries `--hash`, taken from the installation's own
+`checksum` line, and it never carries `--pin` itself: the run above named no
+version at all, and what comes back is
+
+    jpx --hash=SHA-256/ed5600ef...aa1e2dd org.junit.platform.console@6.1.3 --version
+
+which is the line to paste into a CI step, a README or a script. `--modular` and
+`--docker` are carried through where they were given, because they change what
+gets installed and where it runs.
+
+That digest is never taken on trust. `--pin` verifies the installed jars before it
+prints anything, against `--hash` where one was given and against the
+installation's own `checksum` where none was, so a jar swapped underneath an
+existing installation fails the pin rather than being pinned. A short prefix comes
+back at full length: pass `--hash=ed5600ef861c7e86cab68c134c6ca0cf` and the printed
+command carries all 64 characters.
+
+The second line is the **java command that one expands to**: the JVM jpx itself
+runs on, the module or class path with every jar named in full, whatever the
+installation records in `javaOptions`, and the entry point as
+`-m <module>/<main-class>` or as a bare class name. A real launch moves the two
+long path options into a temporary argument file, which is deleted as the process
+exits and would be useless in a printed line, so this form spells them out. Take
+it where jpx should not sit in front of the program at all - a service unit, a
+container image, a profiler's launch configuration. With `--docker`, this is the
+`docker run` command, mounts and all.
+
+Both are calls on the installation, one step short of the process:
+
+    jpx.install(<target>).verify(<hash>).pinned(<arguments>)
+    jpx.install(<target>).verify(<hash>).command(<arguments>)
 
 Where it resolves from
 ----------------------

--- a/demo/demo-50-jpx/build/Demo.java
+++ b/demo/demo-50-jpx/build/Demo.java
@@ -44,6 +44,13 @@ public class Demo {
         // shortest prefix accepted, and it is matched against the recomputed digest.
         launch(jpx, "org.junit.platform.console@6.1.3", "ed5600ef861c7e86cab68c134c6ca0cf");
 
+        // A pinning run stops short of the JVM: the program is resolved, installed and
+        // verified exactly as for a real run, and two commands are printed instead of
+        // launching it - the jpx command that repeats the run reproducibly, and the
+        // java command that one expands to.
+        pin(jpx, "org.junit.platform.console@6.1.3",
+                "ed5600ef861c7e86cab68c134c6ca0cf3b5265e5f2697c16576281452aa1e2dd");
+
         // A digest that does not match the installed jars refuses to launch, on the
         // run that installed them and on every run after it.
         reject(jpx, "org.junit.platform.console@6.1.3",
@@ -66,6 +73,14 @@ public class Demo {
         if (status != 0) {
             throw new IllegalStateException(target + " exited with status " + status);
         }
+    }
+
+    private static void pin(Jpx jpx, String target, String hash) throws Exception {
+        System.out.println();
+        System.out.println("jpx --pin --hash=" + hash + " " + target + " --version");
+        Jpx.Installation installation = jpx.install(target).verify(hash);
+        System.out.println("  [pinned]   " + String.join(" ", installation.pinned(List.of("--version"))));
+        System.out.println("  [expands]  " + String.join(" ", installation.command(List.of("--version"))));
     }
 
     private static void reject(Jpx jpx, String target, String hash) throws Exception {

--- a/sdk/jpx/tests/test.bat
+++ b/sdk/jpx/tests/test.bat
@@ -33,41 +33,41 @@ set "TMPDIR=%TEMP%\jpx-tests-%RANDOM%-%RANDOM%"
 mkdir "%TMPDIR%" || exit /b 1
 set "OUTFILE=%TMPDIR%\out.txt"
 
-REM [1/6] --help prints the usage and exits 0
-echo [1/6] jpx --help
+REM [1/7] --help prints the usage and exits 0
+echo [1/7] jpx --help
 call "%SDK_HOME%\bin\jpx.bat" --help > "%OUTFILE%" 2>&1
 if errorlevel 1 goto :fail
 findstr /c:"Usage: jpx" "%OUTFILE%" >nul || goto :fail
 echo   ok
 
-REM [2/6] no target prints the usage and exits 64
-echo [2/6] jpx without a target
+REM [2/7] no target prints the usage and exits 64
+echo [2/7] jpx without a target
 call "%SDK_HOME%\bin\jpx.bat" > "%OUTFILE%" 2>&1
 set "RC=!ERRORLEVEL!"
 if not "!RC!"=="64" goto :fail
 findstr /c:"Usage: jpx" "%OUTFILE%" >nul || goto :fail
 echo   ok
 
-REM [3/6] an unknown option prints the usage and exits 64
-echo [3/6] jpx with an unknown option
+REM [3/7] an unknown option prints the usage and exits 64
+echo [3/7] jpx with an unknown option
 call "%SDK_HOME%\bin\jpx.bat" --unknown target > "%OUTFILE%" 2>&1
 set "RC=!ERRORLEVEL!"
 if not "!RC!"=="64" goto :fail
 findstr /c:"Unknown option: --unknown" "%OUTFILE%" >nul || goto :fail
 echo   ok
 
-REM [4/6] a malformed --hash is rejected before any resolution work
-echo [4/6] jpx with a malformed --hash
+REM [4/7] a malformed --hash is rejected before any resolution work
+echo [4/7] jpx with a malformed --hash
 call "%SDK_HOME%\bin\jpx.bat" --hash=xyz target > "%OUTFILE%" 2>&1
 set "RC=!ERRORLEVEL!"
 if "!RC!"=="0" goto :fail
 findstr /c:"at least 32 hex characters" "%OUTFILE%" >nul || goto :fail
 echo   ok
 
-REM [5/6] install and launch a sample tool from a file-backed Maven repository;
+REM [5/7] install and launch a sample tool from a file-backed Maven repository;
 REM the redirected home deliberately has no .m2 repository, so the installation
 REM must succeed without a local Maven cache to materialize into.
-echo [5/6] jpx install and launch
+echo [5/7] jpx install and launch
 mkdir "%TMPDIR%\src\exampletool"
 mkdir "%TMPDIR%\classes"
 mkdir "%TMPDIR%\home"
@@ -104,8 +104,8 @@ if not exist "%DESCRIPTOR%" goto :fail
 findstr /c:"classpath=org.example%%2Ftool%%2F1.0.jar" "%DESCRIPTOR%" >nul || goto :fail
 echo   ok
 
-REM [6/6] --hash verifies the recorded checksum prefix and rejects a mismatch
-echo [6/6] jpx --hash verification
+REM [6/7] --hash verifies the recorded checksum prefix and rejects a mismatch
+echo [6/7] jpx --hash verification
 set "CHECKSUM="
 for /f "usebackq tokens=1* delims=/" %%a in (`findstr /b /c:"checksum=SHA-256/" "%DESCRIPTOR%"`) do (
     if not defined CHECKSUM set "CHECKSUM=%%b"
@@ -118,6 +118,18 @@ call "%SDK_HOME%\bin\jpx.bat" --hash=00000000000000000000000000000000 org.exampl
 set "RC=!ERRORLEVEL!"
 if "!RC!"=="0" goto :fail
 findstr /c:"Checksum mismatch" "%OUTFILE%" >nul || goto :fail
+echo   ok
+
+REM [7/7] --pin prints the reproducible command instead of running the tool, filling
+REM in the version the target left out and the digest of what was installed
+echo [7/7] jpx --pin
+del /q "%TMPDIR%\marker.txt" >nul 2>&1
+call "%SDK_HOME%\bin\jpx.bat" --pin org.example:tool "%TMPDIR%\marker.txt" > "%OUTFILE%" 2>&1
+set "RC=!ERRORLEVEL!"
+if not "!RC!"=="0" goto :fail
+findstr /c:"jpx --hash=SHA-256/!CHECKSUM! org.example:tool@1.0" "%OUTFILE%" >nul || goto :fail
+findstr /c:"exampletool.Main" "%OUTFILE%" >nul || goto :fail
+if exist "%TMPDIR%\marker.txt" goto :fail
 echo   ok
 
 rmdir /s /q "%TMPDIR%" >nul 2>&1

--- a/sdk/jpx/tests/test.sh
+++ b/sdk/jpx/tests/test.sh
@@ -45,14 +45,14 @@ dump_and_fail() {
     exit 1
 }
 
-# [1/6] --help prints the usage and exits 0
-echo "[1/6] jpx --help"
+# [1/7] --help prints the usage and exits 0
+echo "[1/7] jpx --help"
 OUT="$("${SDK_HOME}/bin/jpx" --help 2>&1)" || dump_and_fail "jpx --help exited non-zero" "$OUT"
 printf '%s' "$OUT" | grep -qF "Usage: jpx" || dump_and_fail "missing usage banner" "$OUT"
 echo "  ok"
 
-# [2/6] no target prints the usage and exits 64
-echo "[2/6] jpx without a target"
+# [2/7] no target prints the usage and exits 64
+echo "[2/7] jpx without a target"
 set +e
 OUT="$("${SDK_HOME}/bin/jpx" 2>&1)"
 RC=$?
@@ -61,8 +61,8 @@ set -e
 printf '%s' "$OUT" | grep -qF "Usage: jpx" || dump_and_fail "missing usage banner" "$OUT"
 echo "  ok"
 
-# [3/6] an unknown option prints the usage and exits 64
-echo "[3/6] jpx with an unknown option"
+# [3/7] an unknown option prints the usage and exits 64
+echo "[3/7] jpx with an unknown option"
 set +e
 OUT="$("${SDK_HOME}/bin/jpx" --unknown target 2>&1)"
 RC=$?
@@ -71,8 +71,8 @@ set -e
 printf '%s' "$OUT" | grep -qF "Unknown option: --unknown" || dump_and_fail "missing unknown-option line" "$OUT"
 echo "  ok"
 
-# [4/6] a malformed --hash is rejected before any resolution work
-echo "[4/6] jpx with a malformed --hash"
+# [4/7] a malformed --hash is rejected before any resolution work
+echo "[4/7] jpx with a malformed --hash"
 set +e
 OUT="$("${SDK_HOME}/bin/jpx" --hash=xyz target 2>&1)"
 RC=$?
@@ -81,10 +81,10 @@ set -e
 printf '%s' "$OUT" | grep -qF "at least 32 hex characters" || dump_and_fail "missing checksum complaint" "$OUT"
 echo "  ok"
 
-# [5/6] install and launch a sample tool from a file-backed Maven repository;
+# [5/7] install and launch a sample tool from a file-backed Maven repository;
 # the redirected home deliberately has no .m2 repository, so the installation
 # must succeed without a local Maven cache to materialize into.
-echo "[5/6] jpx install and launch"
+echo "[5/7] jpx install and launch"
 mkdir -p "$TMPDIR/src/exampletool" "$TMPDIR/classes" "$TMPDIR/home"
 cat > "$TMPDIR/src/exampletool/Main.java" <<'SOURCE'
 package exampletool;
@@ -118,8 +118,8 @@ DESCRIPTOR="$TMPDIR/home/.jenesis/jpx/maven/org.example--tool@1.0/jpx.properties
 grep -qF "classpath=org.example%2Ftool%2F1.0.jar" "$DESCRIPTOR" || dump_and_fail "descriptor does not record the encoded coordinate" "$(cat "$DESCRIPTOR")"
 echo "  ok"
 
-# [6/6] --hash verifies the recorded checksum prefix and rejects a mismatch
-echo "[6/6] jpx --hash verification"
+# [6/7] --hash verifies the recorded checksum prefix and rejects a mismatch
+echo "[6/7] jpx --hash verification"
 CHECKSUM="$(sed -n 's/^checksum=SHA-256\///p' "$DESCRIPTOR")"
 [ -n "$CHECKSUM" ] || dump_and_fail "no checksum recorded in $DESCRIPTOR"
 set +e
@@ -133,6 +133,22 @@ RC=$?
 set -e
 [ "$RC" != "0" ] || dump_and_fail "expected a checksum mismatch failure" "$OUT"
 printf '%s' "$OUT" | grep -qF "Checksum mismatch" || dump_and_fail "missing mismatch message" "$OUT"
+echo "  ok"
+
+# [7/7] --pin prints the reproducible command instead of running the tool, filling
+# in the version the target left out and the digest of what was installed
+echo "[7/7] jpx --pin"
+rm -f "$TMPDIR/marker.txt"
+set +e
+OUT="$("${SDK_HOME}/bin/jpx" --pin org.example:tool "$TMPDIR/marker.txt" 2>&1)"
+RC=$?
+set -e
+[ "$RC" = "0" ] || dump_and_fail "expected --pin to exit 0, got $RC" "$OUT"
+printf '%s\n' "$OUT" | head -1 | grep -qF "jpx --hash=SHA-256/${CHECKSUM} org.example:tool@1.0" \
+    || dump_and_fail "the pinned command does not carry the digest and the resolved version" "$OUT"
+printf '%s\n' "$OUT" | tail -1 | grep -qF "exampletool.Main" \
+    || dump_and_fail "the expanded command does not name the main class" "$OUT"
+[ ! -f "$TMPDIR/marker.txt" ] || dump_and_fail "--pin launched the tool" "$OUT"
 echo "  ok"
 
 echo "jpx-tests: all checks passed"

--- a/sources/build/jenesis/Jpx.java
+++ b/sources/build/jenesis/Jpx.java
@@ -125,6 +125,45 @@ public record Jpx(Path storage,
             }
         }
 
+        public List<String> command(List<String> arguments) throws IOException {
+            return command(null, arguments);
+        }
+
+        public List<String> command(String mainClass, List<String> arguments) throws IOException {
+            List<String> command = new ArrayList<>();
+            command.add(Path.of(System.getProperty("java.home"), "bin", File.separatorChar == '\\' ? "java.exe" : "java").toString());
+            command.addAll(javaArguments(mainClass, arguments, null));
+            return command;
+        }
+
+        public List<String> command(String mainClass, List<String> arguments, DockerizedJava docker)
+                throws IOException, InterruptedException {
+            return docker.mount(folder, folder.toString(), true)
+                    .command(javaArguments(mainClass, arguments, null));
+        }
+
+        public List<String> pinned(List<String> arguments) throws IOException {
+            return pinned(Collections.emptyList(), null, arguments);
+        }
+
+        public List<String> pinned(List<String> options, String mainClass, List<String> arguments) throws IOException {
+            SequencedProperties properties = properties();
+            String name = properties.getProperty("name"), version = properties.getProperty("version");
+            String checksum = properties.getProperty("checksum");
+            if (name == null || version == null || checksum == null) {
+                throw new IllegalStateException("The installation " + folder.getFileName()
+                        + " does not record a name, a version and a checksum"
+                        + " - reinstall the target to pin what it resolved to");
+            }
+            List<String> command = new ArrayList<>();
+            command.add("jpx");
+            command.addAll(options);
+            command.add("--hash=" + checksum);
+            command.add(name + "@" + version + (mainClass == null ? "" : "/" + mainClass));
+            command.addAll(arguments);
+            return command;
+        }
+
         public List<String> javaArguments(String mainClass, List<String> arguments, Path argumentFile)
                 throws IOException {
             SequencedProperties properties = properties();
@@ -139,7 +178,16 @@ public record Jpx(Path storage,
             SequencedMap<String, String> options = new LinkedHashMap<>();
             options.put("-p", modulepath == null ? null : join(modulepath));
             options.put("-cp", classpath == null ? null : join(classpath));
-            command.addAll(ProcessBuildStep.argumentFile(argumentFile, options));
+            if (argumentFile == null) {
+                options.forEach((option, value) -> {
+                    if (value != null && !value.isEmpty()) {
+                        command.add(option);
+                        command.add(value);
+                    }
+                });
+            } else {
+                command.addAll(ProcessBuildStep.argumentFile(argumentFile, options));
+            }
             if (modulepath != null) {
                 command.addAll(ModuleGraph.load(properties));
             }
@@ -176,7 +224,7 @@ public record Jpx(Path storage,
     }
 
     public static final String HELP = """
-            Usage: jpx [--modular] [--docker[=<image>]] [--hash=<checksum>] <target> [argument...]
+            Usage: jpx [--modular] [--docker[=<image>]] [--hash=<checksum>] [--pin] <target> [argument...]
 
             Runs the main entry point of a published module, resolving and installing
             it on first use.
@@ -208,17 +256,26 @@ public record Jpx(Path storage,
                                   an image, a minimal hardened image is used
               --hash=<checksum>   verify the installed jars against a SHA-256 digest
                                   prefix (at least 32 hex characters) before launching
+              --pin               print two commands instead of launching the program:
+                                  the jpx command that repeats this run reproducibly,
+                                  with the resolved version and the installation's
+                                  digest spelled out, and the java command it expands
+                                  to. The jars are verified before anything is printed
+                                  - against --hash where one is given, and against the
+                                  installation's own digest otherwise - so a printed
+                                  command is one that runs
               --help              print this help""";
 
     public static void main(String... arguments) throws IOException, InterruptedException {
         PathPlacement placement = PathPlacement.INFERRED;
-        boolean dockerized = false;
+        boolean dockerized = false, pin = false;
         String image = null, checksum = null;
         int target = 0;
         while (target < arguments.length && arguments[target].startsWith("--")) {
             switch (arguments[target]) {
                 case "--modular" -> placement = PathPlacement.MODULE_PATH;
                 case "--docker" -> dockerized = true;
+                case "--pin" -> pin = true;
                 case "--help" -> {
                     System.out.println(HELP);
                     System.exit(0);
@@ -249,17 +306,34 @@ public record Jpx(Path storage,
                     + "not Maven coordinates: " + command.name());
         }
         Installation installation = new Jpx(placement).install(command);
+        if (checksum == null && pin) {
+            checksum = installation.properties().getProperty("checksum");
+        }
         if (checksum != null) {
             installation.verify(checksum);
         }
         List<String> remaining = List.of(arguments).subList(target + 1, arguments.length);
+        List<String> options = new ArrayList<>();
+        if (placement == PathPlacement.MODULE_PATH) {
+            options.add("--modular");
+        }
+        DockerizedJava docker = null;
         if (dockerized) {
             Path workingDirectory = Path.of("").toAbsolutePath();
-            System.exit(installation.launch(command.mainClass(), remaining, image == null
+            docker = image == null
                     ? new DockerizedJava(workingDirectory)
-                    : new DockerizedJava(workingDirectory, image)));
-        } else {
+                    : new DockerizedJava(workingDirectory, image);
+            options.add(image == null ? "--docker" : "--docker=" + image);
+        }
+        if (pin) {
+            System.out.println(String.join(" ", installation.pinned(options, command.mainClass(), remaining)));
+            System.out.println(String.join(" ", docker == null
+                    ? installation.command(command.mainClass(), remaining)
+                    : installation.command(command.mainClass(), remaining, docker)));
+        } else if (docker == null) {
             System.exit(installation.launch(command.mainClass(), remaining));
+        } else {
+            System.exit(installation.launch(command.mainClass(), remaining, docker));
         }
     }
 

--- a/tests/build/jenesis/test/JpxTest.java
+++ b/tests/build/jenesis/test/JpxTest.java
@@ -536,6 +536,88 @@ public class JpxTest {
     }
 
     @Test
+    public void command_spells_out_the_paths_instead_of_writing_an_argument_file() throws IOException {
+        Path folder = Files.createDirectories(work.resolve("crafted@1.0"));
+        SequencedProperties properties = new SequencedProperties();
+        properties.setProperty("mainModule", "tool.main");
+        properties.setProperty("mainClass", "toolmain.Main");
+        properties.setProperty("modulepath", "tool-main.jar");
+        properties.setProperty("classpath", "legacy.jar");
+        properties.store(folder.resolve(Jpx.PROPERTIES));
+        Jpx.Installation installation = new Jpx.Installation(folder, new HashDigestFunction("SHA-256"));
+
+        List<String> command = installation.command(List.of("run"));
+
+        assertThat(command.getFirst())
+                .as("a printed command names the JVM that would run it")
+                .isEqualTo(Path.of(System.getProperty("java.home"),
+                        "bin",
+                        File.separatorChar == '\\' ? "java.exe" : "java").toString());
+        assertThat(command)
+                .as("a command that is only printed cannot lean on a temporary argument file")
+                .containsSubsequence(
+                        "-p", folder.resolve("tool-main.jar").toString(),
+                        "-cp", folder.resolve("legacy.jar").toString(),
+                        "-m", "tool.main/toolmain.Main",
+                        "run");
+        try (Stream<Path> entries = Files.list(folder)) {
+            assertThat(entries.filter(entry -> entry.getFileName().toString().endsWith(".args")))
+                    .as("nothing is written for a command that is not run")
+                    .isEmpty();
+        }
+    }
+
+    @Test
+    public void docker_command_mounts_the_installation_and_spells_out_the_paths()
+            throws IOException, InterruptedException {
+        addMavenTool();
+        Jpx.Installation installation = jpx().install("org.example:tool-main@1.0");
+        RecordingDocker docker = new RecordingDocker(work);
+
+        List<String> command = installation.command(null, List.of("argument"), docker);
+
+        assertThat(docker.host).isEqualTo(installation.folder());
+        assertThat(docker.readOnly).isTrue();
+        assertThat(command).startsWith("docker", "run", "recording-image");
+        assertThat(docker.javaArgs).containsSubsequence("-cp", "toolmain.Main", "argument");
+        try (Stream<Path> entries = Files.list(installation.folder())) {
+            assertThat(entries.filter(entry -> entry.getFileName().toString().endsWith(".args")))
+                    .as("nothing is written for a command that is not run")
+                    .isEmpty();
+        }
+    }
+
+    @Test
+    public void pinned_command_names_the_resolved_version_and_the_installed_digest() throws IOException {
+        addPlainTool("2.0");
+        addMavenMetadata("plain-tool", "2.0", "1.0", "2.0");
+        Jpx.Installation installation = jpx().install("org.example:plain-tool");
+
+        List<String> pinned = installation.pinned(List.of("run"));
+
+        assertThat(pinned)
+                .as("a target that named no version pins the one it resolved to, so the command repeats")
+                .containsExactly("jpx",
+                        "--hash=" + installation.properties().getProperty("checksum"),
+                        "org.example:plain-tool@2.0",
+                        "run");
+    }
+
+    @Test
+    public void pinned_command_carries_the_options_and_the_named_entry_point() throws IOException {
+        addMavenTool();
+        Jpx.Installation installation = jpx().install("org.example:tool-main@1.0");
+
+        List<String> pinned = installation.pinned(List.of("--docker"), "other.Main", List.of("run"));
+
+        assertThat(pinned).containsExactly("jpx",
+                "--docker",
+                "--hash=" + installation.properties().getProperty("checksum"),
+                "org.example:tool-main@1.0/other.Main",
+                "run");
+    }
+
+    @Test
     public void java_arguments_add_all_module_path_for_a_legacy_installation() throws IOException {
         Path folder = Files.createDirectories(work.resolve("crafted@1.0"));
         SequencedProperties properties = new SequencedProperties();
@@ -696,6 +778,14 @@ public class JpxTest {
         public int execute(List<String> javaArgs) {
             this.javaArgs = javaArgs;
             return 42;
+        }
+
+        @Override
+        public List<String> command(List<String> javaArgs) {
+            this.javaArgs = javaArgs;
+            List<String> command = new ArrayList<>(List.of("docker", "run", image()));
+            command.addAll(javaArgs);
+            return command;
         }
     }
 


### PR DESCRIPTION
A target typed at a prompt is rarely the target you want in a pipeline: the version floats and nothing pins the bytes. `--pin` closes that gap without asking anyone to transcribe a digest by hand. It resolves, installs and verifies exactly as a launch does, then prints two commands instead of starting the JVM.

```
$ jpx --pin org.junit.platform.console --version
jpx --hash=SHA-256/ed5600...aa1e2dd org.junit.platform.console@6.1.3 --version
/path/to/bin/java -p ...jar:...jar -m org.junit.platform.console/...ConsoleLauncher --version
```

## The first line: the jpx command that repeats the run

Whatever the target left out is filled in. The version is the one that resolved -- the run above named none -- and `--hash` is always present, at full length, taken from the installation's own `checksum`, so a 32-character prefix passed in comes back as all 64. `--pin` itself is dropped, because the printed line is the one you would run for real. `--modular` and `--docker[=<image>]` are carried through, since they decide what gets installed and where it runs.

## The second line: the java command it expands to

For the places jpx should not sit in front of the program at all -- a service unit, a container image, a profiler's launch configuration. A launch hides the two long path options in a temporary argument file, which is deleted with the process and would be useless in a printed line, so this form spells them out and runs as it stands. Under `--docker` it is the `docker run` command, mounts and all.

## The digest is not taken on trust

The jars are verified before anything is printed: against `--hash` where one was given, and against the installation's own recorded checksum where none was. So a jar swapped underneath an existing installation fails the pin rather than being pinned, and a printed command is one that runs.

```
$ jpx --pin org.junit.platform.console --version      # after tampering with one jar
Exception ... expected a digest starting with ...aa1e2dd but computed 560f8764...
exit=1
```

## API

Both lines are calls on the installation, one step short of the process, and both chain after `verify`:

```java
installation.pinned(arguments)                        // jpx --hash=... name@version args
installation.pinned(options, mainClass, arguments)
installation.command(arguments)                       // java -p ... -m ... args
installation.command(mainClass, arguments)
installation.command(mainClass, arguments, docker)    // docker run ...
```

`javaArguments(mainClass, arguments, file)` now accepts a `null` file, keeping the paths on the returned list instead of spilling them.

## Verified

- `mvn test`: 1844 pass, with four new tests. One installs a target that names **no** version (resolved through `maven-metadata.xml`) and asserts the pinned line reads `org.example:plain-tool@2.0` with the descriptor's digest; the others cover option and entry-point pass-through, and that neither `command` form writes an argument file.
- `sdk/jpx/tests/test.sh` and `test.bat` gain a seventh step running `jpx --pin org.example:tool` with neither a version nor a hash, asserting the first printed line is `jpx --hash=SHA-256/<digest> org.example:tool@1.0` and that the tool did not run. Run against a staged jar: 7/7 pass.
- `demo/demo-50-jpx` gains a pinning run; its CI verification (2 descriptors) still holds.
- Clean self-build and `stage` green.
- The user documentation is updated in jenesis/jenesis-documentation.